### PR TITLE
feat: add fallback theme for unresolved cards

### DIFF
--- a/frontend/src/components/game/Card.vue
+++ b/frontend/src/components/game/Card.vue
@@ -35,7 +35,7 @@ const props = defineProps<{
 }>();
 
 const cardTheme = useCardTheme();
-const cardData = computed(() => (props.overrideTheme ?? cardTheme.theme).getCard(props.card));
+const cardData = computed(async () => await (props.overrideTheme ?? cardTheme.theme).getCard(props.card));
 </script>
 <style scoped>
 .zwoo-card:not(:first-of-type) {

--- a/frontend/src/core/domain/cards/CardTheme.ts
+++ b/frontend/src/core/domain/cards/CardTheme.ts
@@ -9,6 +9,7 @@ import {
   CardThemeInformation,
   MAX_THEME_PREVIEWS
 } from './CardThemeConfig';
+import { CardThemeManager } from './ThemeManager';
 
 export type SerializedCardTheme = {
   name: string;
@@ -44,7 +45,7 @@ export class CardTheme {
     return this.config.colors[this.variant];
   }
 
-  public getCard(card: Card | CardDescriptor | string): CardImageData {
+  public async getCard(card: Card | CardDescriptor | string): Promise<CardImageData> {
     const layers: string[] = [];
     if (Object.values(CardDescriptor).includes(card as CardDescriptor)) {
       layers.push(card as string);
@@ -55,10 +56,18 @@ export class CardTheme {
     } else {
       layers.push(...this.cardToURI(card));
     }
-    return {
+
+    const cardData = {
       layers: layers.map(identifier => this.data[identifier] ?? ''),
       description: typeof card === 'string' ? card : this.cardToAbsoluteUri(card)
     };
+
+    if (cardData.layers.some(layer => !layer)) {
+      const defaultTheme = await this.getDefaultTheme();
+      return defaultTheme.getCard(card);
+    }
+
+    return cardData;
   }
 
   private cardToAbsoluteUri(card: Card): string {
@@ -79,6 +88,11 @@ export class CardTheme {
       CardLayerSeparator + CardLayerWildcard + CardLayerSeparator
     );
     return [firstLayer, secondLayer];
+  }
+
+  private async getDefaultTheme(): Promise<CardTheme> {
+    const defaultThemeIdentifier = await CardThemeManager.global.getDefaultTheme();
+    return CardThemeManager.global.loadTheme(defaultThemeIdentifier);
   }
 
   public toJson(): SerializedCardTheme {


### PR DESCRIPTION
Implement a fallback mechanism to revert to the default theme if a card from the selected theme cannot be resolved.

* **CardTheme.ts**
  - Update `getCard` method to include a fallback mechanism to revert to the default theme if a card from the selected theme cannot be resolved.
  - Add a private method `getDefaultTheme` to retrieve the default theme.
  - Add `async` modifier to `getCard` method.

* **Card.vue**
  - Update the call to `getCard` to use `await`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fabiankachlock/zwoo?shareId=41e88029-fbd2-4291-82d4-45ee7d6e46ba).